### PR TITLE
Added Dark background on AirBuddy Page

### DIFF
--- a/frontend/src/components/airbuddy/AQIHeader.jsx
+++ b/frontend/src/components/airbuddy/AQIHeader.jsx
@@ -2,7 +2,7 @@ import { getAQIColor, getAQILabel, getAQIBgColor } from '../../lib/aqiUtils';
 
 export function AQIHeader({ aqi, location, lastUpdated }) {
   return (
-    <div className={`rounded-2xl p-6 border ${getAQIBgColor(aqi)}`}>
+    <div className={`rounded-2xl p-6 border ${getAQIBgColor(aqi)} dark:bg-card transition-all duration-300`}>
       <div className="flex items-center justify-between mb-6">
         <div>
           <h2 className="text-2xl font-bold text-foreground">Air Quality Index</h2>

--- a/frontend/src/components/airbuddy/HealthAdvisory.jsx
+++ b/frontend/src/components/airbuddy/HealthAdvisory.jsx
@@ -5,7 +5,7 @@ export function HealthAdvisory({ aqi }) {
   const recommendations = getHealthRecommendations(aqi);
 
   return (
-    <div className={`rounded-2xl p-6 border ${getAQIBgColor(aqi)}`}>
+    <div className={`rounded-2xl p-6 border ${getAQIBgColor(aqi)} dark:bg-card transition-all duration-300`}>
       <div className="flex items-center gap-3 mb-4">
         <Heart className="h-6 w-6 text-red-500" />
         <h3 className="text-xl font-bold text-foreground">Health Recommendations</h3>
@@ -13,14 +13,14 @@ export function HealthAdvisory({ aqi }) {
       
       <div className="space-y-3">
         {recommendations.map((recommendation, index) => (
-          <div key={index} className="flex items-start gap-3 p-3 bg-white bg-opacity-50 rounded-lg">
-            <div className="text-sm text-foreground">{recommendation}</div>
+          <div key={index} className="flex items-start gap-3 p-3 dark:bg-card transition-all duration-300 bg-opacity-50 rounded-lg border">
+            <div className="text-sm text-foreground ">{recommendation}</div>
           </div>
         ))}
       </div>
       
       {aqi > 100 && (
-        <div className="mt-4 p-3 bg-red-100 border border-red-200 rounded-lg">
+        <div className="mt-4 p-3 dark:bg-card transition-all duration-300 rounded-lg">
           <p className="text-sm text-red-800 font-medium">
             ⚠️ Sensitive groups include children, elderly, and people with heart or lung conditions.
           </p>

--- a/frontend/src/components/airbuddy/PollutantGrid.jsx
+++ b/frontend/src/components/airbuddy/PollutantGrid.jsx
@@ -9,7 +9,7 @@ export function PollutantGrid({ pollutants }) {
       blue: 'bg-blue-50 border-blue-200 text-blue-900',
       red: 'bg-red-50 border-red-200 text-red-900',
       orange: 'bg-orange-50 border-orange-200 text-orange-900',
-      gray: 'bg-gray-50 border-gray-200 text-gray-900',
+      gray: 'bg-gray-50 border-gray-200 text-gray-400',
       green: 'bg-green-50 border-green-200 text-green-900',
     };
     return colors[color] || colors.gray;
@@ -35,7 +35,7 @@ export function PollutantGrid({ pollutants }) {
         const percentage = Math.min((value / (info.maxSafe * 3)) * 100, 100);
 
         return (
-          <div key={key} className={`rounded-xl p-4 border ${getColorClasses(info.color)}`}>
+          <div key={key} className={`rounded-xl p-4 border ${getColorClasses(info.color)} dark:bg-card transition-all duration-300`}>
             <div className="flex items-center justify-between mb-3">
               <div>
                 <h4 className="font-semibold">{info.name}</h4>

--- a/frontend/src/components/airbuddy/TrendChart.jsx
+++ b/frontend/src/components/airbuddy/TrendChart.jsx
@@ -4,7 +4,7 @@ import { convertToStandardAQI } from '../../lib/api/airbuddy';
 export function TrendChart({ historyData, pollutant = 'aqi' }) {
   if (!historyData || !historyData.length) {
     return (
-      <div className="bg-white rounded-2xl p-6 border">
+      <div className="dark:bg-card transition-all duration-300 rounded-2xl p-6 border">
         <h3 className="text-xl font-bold text-foreground mb-4">48-Hour Trend</h3>
         <div className="flex items-center justify-center h-64 text-muted-foreground">
           No trend data available
@@ -58,11 +58,11 @@ export function TrendChart({ historyData, pollutant = 'aqi' }) {
   };
 
   return (
-    <div className="bg-white rounded-2xl p-6 border">
+    <div className="dark:bg-card transition-all duration-300 rounded-2xl p-6 border">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-xl font-bold text-foreground">48-Hour Trend</h3>
         <select 
-          className="text-sm border rounded px-2 py-1"
+          className="text-sm border rounded px-2 py-1 dark:bg-card transition-all duration-300"
           onChange={(e) => {
             // This would need to be handled by parent component
             console.log('Selected pollutant:', e.target.value);

--- a/frontend/src/contexts/ThemeContext.jsx
+++ b/frontend/src/contexts/ThemeContext.jsx
@@ -73,7 +73,7 @@ export const ThemeProvider = ({ children }) => {
   };
 
   const toggleTheme = () => {
-    setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
+    setTheme((prevTheme) =>(prevTheme === "light" ? "dark" : "light"));
   };
 
   const updateAccentColor = (color) => {

--- a/frontend/src/pages/AirBuddy.jsx
+++ b/frontend/src/pages/AirBuddy.jsx
@@ -99,9 +99,9 @@ function AirBuddy() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-green-50">
+    <div className="min-h-screen bg-background text-foreground">
       {/* Header */}
-      <div className="bg-white shadow-sm border-b">
+      <div className="bg-card shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-3">


### PR DESCRIPTION
## 📋 Description

Fixed #131 
The AirBuddy Page dark mode was not working due to hardcoded background values. In this PR , i replaced the bg-values with program values (dark:bg-background & dark:bg-card). 

Also after making changes, the 'CO levels' div block under 'Pollutant Levels' div block was not much visible [ due to dark background being gray and same does the text color was ] - so i increased the gray color intensity 
Old Value - gray/900 
New Value - gray/400

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📸 Screenshots (if applicable)

**Before:**
<img width="1919" height="965" alt="image" src="https://github.com/user-attachments/assets/1a9df1de-fbbd-49f1-88f2-2115d399d7c8" />
<img width="1919" height="970" alt="image" src="https://github.com/user-attachments/assets/1c9e9e1a-a924-4282-ba33-563695f607e8" />

**After:**
<img width="1918" height="960" alt="image" src="https://github.com/user-attachments/assets/dfdf4497-3192-44f0-a0c7-109220c507ad" />
<img width="1919" height="969" alt="image" src="https://github.com/user-attachments/assets/9995b465-2d87-4a4f-b33d-5ff758cff75f" />
