### PR TITLE
Fixed Carbon Saved, Eco Score, Local Purchases and Community Rank num…

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -511,7 +511,7 @@ const Dashboard = () => {
                     {stat.change}
                   </span>
                 </div>
-                <h3 className="text-3xl font-extrabold text-foreground mb-1 group-hover:scale-110 transition-transform duration-300 origin-left">
+                <h3 className="text-3xl dark:text-black font-extrabold text-foreground mb-1 group-hover:scale-110 transition-transform duration-300 origin-left">
                   {stat.value}
                 </h3>
                 <p className="text-muted-foreground font-semibold group-hover:text-foreground transition-colors duration-300">


### PR DESCRIPTION
## 📋 Description

Fixed Carbon Saved, Eco Score, Local Purchases and Community Rank numbers not visible in dark mode.

## 🔗 Related Issue

Fixes #152 

## 🚀 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI changes
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvements
- [ ] 🧪 Test additions or updates

## 📸 Screenshots 

**Before:**

<img width="2559" height="1599" alt="Screenshot 2026-02-09 170232" src="https://github.com/user-attachments/assets/9cbb6a00-f9c7-4e32-b5a3-66466093dee0" />

**After:**

<img width="2320" height="501" alt="Screenshot 2026-02-17 151411" src="https://github.com/user-attachments/assets/7fddd48e-c1ab-420a-8d04-e89038eb46b6" />

@Meghali54 please review it :)