### PR TITLE
feat: add page loader/spinner on route transitions (fixes #149)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import LocalHarvest from "./pages/LocalHarvest";
 import WasteLess from "./pages/WasteLess";
 import CarbonFootprintCalculator from "./pages/CarbonFootprintCalculator";
 import BackToTop from "./components/BackToTop";
+import RouteChangeLoader from "./components/RouteChangeLoader";
 import AOS from "aos";
 import Feedback from "./pages/Feedback"; 
 import "aos/dist/aos.css";
@@ -29,6 +30,7 @@ const App = () => {
     <ThemeProvider>
       <AuthProvider>
         <BrowserRouter>
+          <RouteChangeLoader />
           <BackToTop />
           <Routes>
             <Route path="/" element={<Landing />} />

--- a/frontend/src/components/PageLoader.jsx
+++ b/frontend/src/components/PageLoader.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+/**
+ * Full-screen overlay spinner shown during page transitions.
+ * Uses the project's eco-green accent colour so it fits the brand.
+ */
+const PageLoader = () => {
+  return (
+    <div className="fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm">
+      {/* Leaf-ring spinner */}
+      <div className="relative flex items-center justify-center w-20 h-20">
+        {/* Outer spinning ring */}
+        <span className="absolute inline-block w-20 h-20 rounded-full border-4 border-green-200 dark:border-green-900" />
+        <span className="absolute inline-block w-20 h-20 rounded-full border-4 border-transparent border-t-green-500 animate-spin" />
+        {/* Inner leaf icon */}
+        <span className="text-3xl select-none" role="img" aria-label="leaf">
+          🌿
+        </span>
+      </div>
+      <p className="mt-4 text-sm font-medium text-green-600 dark:text-green-400 tracking-wide animate-pulse">
+        Loading…
+      </p>
+    </div>
+  );
+};
+
+export default PageLoader;

--- a/frontend/src/components/RouteChangeLoader.jsx
+++ b/frontend/src/components/RouteChangeLoader.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+import PageLoader from "./PageLoader";
+
+/**
+ * Listens to React Router location changes and renders a full-screen
+ * PageLoader for a short duration on every navigation, giving users
+ * clear visual feedback when switching between pages.
+ */
+const RouteChangeLoader = () => {
+  const location = useLocation();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    // Show the loader immediately when the route changes
+    setLoading(true);
+
+    // Hide it after a short delay — long enough to be visible, short
+    // enough not to block the user (300 ms feels snappy but noticeable).
+    const timer = setTimeout(() => setLoading(false), 300);
+
+    return () => clearTimeout(timer);
+  }, [location.pathname]);
+
+  return loading ? <PageLoader /> : null;
+};
+
+export default RouteChangeLoader;


### PR DESCRIPTION
"feat: add page loader/spinner on route transitions (fixes #149)

- Add PageLoader component: full-screen overlay with green spinning ring,
  leaf icon and pulsing 'Loading...' text matching eco-brand
- Add RouteChangeLoader component: uses useLocation() to detect every
  route change and shows PageLoader for 300ms on each navigation
- Wire RouteChangeLoader into App.jsx inside BrowserRouter so it covers
  all routes globally"


-
## 📸 Screenshots (if applicable)

<img width="1825" height="859" alt="Screenshot 2026-03-03 053413" src="https://github.com/user-attachments/assets/a19f6d39-ac6b-4d85-a850-a28b307e1fe9" />




