### PR TITLE
fix: Add fail-fast validation for MONGO_URI on backend startup (Resolves #214)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 backend/.env
 frontend/.env
 
+# Environment templates (allowed)
+!.env.example
+!backend/.env.example
+!frontend/.env.example
+
 # Dependencies
 node_modules/
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -103,12 +103,17 @@ npm install
 
 ### 3. Set up environment variables
 
-```bash
-# In the backend directory, create a .env file
-cd backend
-cp .env.example .env
-# Edit .env with your configuration
-```
+1. Navigate to the backend directory:
+   ```bash
+   cd backend
+   ```
+
+2. Copy the environment template file:
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Open the newly created .env file and replace the placeholder values with your actual MongoDB URI and secret keys.
 
 ### 4. Start the development servers
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+# Backend Environment Variables Template
+# Copy this file to .env and replace the placeholder values with your actual credentials.
+# DO NOT commit your actual .env file to version control.
+
+PORT=5000
+MONGO_URI=your_mongodb_connection_string_here
+JWT_SECRET=your_jwt_secret_here
+JWT_EXPIRES_IN=7d

--- a/backend/index.js
+++ b/backend/index.js
@@ -9,6 +9,12 @@ import dotenv from "dotenv";
 // Load environment variables
 dotenv.config();
 
+// Validate critical environment variables before attempting connection
+if (!process.env.MONGO_URI) {
+  console.error("FATAL ERROR: MONGO_URI is not defined in environment variables.");
+  process.exit(1);
+}
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 app.use(cors());

--- a/frontend/src/components/EcoTipsCarousel.jsx
+++ b/frontend/src/components/EcoTipsCarousel.jsx
@@ -110,9 +110,19 @@ const EcoTipsCarousel = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isAutoPlaying, setIsAutoPlaying] = useState(true);
   const [displayedTips, setDisplayedTips] = useState([0, 1, 2]);
-  const [doneTips, setDoneTips] = useState(() =>
-    JSON.parse(localStorage.getItem('verdigo_done_tips') || '[]')
-  );
+  const [doneTips, setDoneTips] = useState(() => {
+  const saved = localStorage.getItem('verdigo_done_tips');
+  let parsed = [];
+  if (saved) {
+    try {
+      parsed = JSON.parse(saved);
+    } catch (error) {
+      console.warn('Corrupted localStorage data detected. Falling back to defaults.');
+      parsed = []; // Fallback to safe default state
+    }
+  }
+  return parsed;
+});
 
   const toggleDone = (id) => {
     setDoneTips((prev) => {

--- a/frontend/src/components/calculator/CarbonCalculator.jsx
+++ b/frontend/src/components/calculator/CarbonCalculator.jsx
@@ -28,7 +28,15 @@ export function CarbonCalculator() {
   // Initialize data from localStorage or defaults
   const [homeData, setHomeData] = useState(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
-    const parsed = saved ? JSON.parse(saved) : {};
+    let parsed = {};
+    if (saved) {
+      try {
+        parsed = JSON.parse(saved);
+      } catch (error) {
+        console.warn('Corrupted localStorage data detected. Falling back to defaults.');
+        parsed = {}; // Fallback to safe default state
+      }
+    }
     return (
       parsed.homeData || {
         monthlyElectricity: 300,
@@ -41,7 +49,15 @@ export function CarbonCalculator() {
 
   const [transportData, setTransportData] = useState(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
-    const parsed = saved ? JSON.parse(saved) : {};
+    let parsed = {};
+    if (saved) {
+      try {
+        parsed = JSON.parse(saved);
+      } catch (error) {
+        console.warn('Corrupted localStorage data detected. Falling back to defaults.');
+        parsed = {}; // Fallback to safe default state
+      }
+    }
     return (
       parsed.transportData || {
         carFuelType: "petrol",
@@ -56,7 +72,15 @@ export function CarbonCalculator() {
 
   const [foodData, setFoodData] = useState(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
-    const parsed = saved ? JSON.parse(saved) : {};
+    let parsed = {};
+    if (saved) {
+      try {
+        parsed = JSON.parse(saved);
+      } catch (error) {
+        console.warn('Corrupted localStorage data detected. Falling back to defaults.');
+        parsed = {}; // Fallback to safe default state
+      }
+    }
     return (
       parsed.foodData || {
         dietType: "mixed",
@@ -71,7 +95,15 @@ export function CarbonCalculator() {
 
   const [wasteData, setWasteData] = useState(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
-    const parsed = saved ? JSON.parse(saved) : {};
+    let parsed = {};
+    if (saved) {
+      try {
+        parsed = JSON.parse(saved);
+      } catch (error) {
+        console.warn('Corrupted localStorage data detected. Falling back to defaults.');
+        parsed = {}; // Fallback to safe default state
+      }
+    }
     return (
       parsed.wasteData || {
         recyclesPaper: true,

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -18,7 +18,12 @@ export const AuthProvider = ({ children }) => {
     // Check if user is logged in on app start
     const storedUser = localStorage.getItem("verdigo_user");
     if (storedUser) {
-      setUser(JSON.parse(storedUser));
+      try {
+        setUser(JSON.parse(storedUser));
+      } catch (error) {
+        console.warn('Corrupted localStorage user data detected. Falling back to defaults.');
+        setUser(null); // Fallback to safe default state
+      }
     }
   }, []);
 

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -225,12 +225,34 @@ const Dashboard = () => {
 
   // ── Notification Bell ────────────────────────────────────────────────────
   const [showNotifications, setShowNotifications] = useState(false);
-  const [readIds, setReadIds] = useState(() =>
-    JSON.parse(localStorage.getItem("verdigo_read_notifs") || "[]")
-  );
+  const [readIds, setReadIds] = useState(() => {
+  const saved = localStorage.getItem("verdigo_read_notifs");
+  let parsed = [];
+  if (saved) {
+    try {
+      parsed = JSON.parse(saved);
+    } catch (error) {
+      console.warn('Corrupted localStorage data detected. Falling back to defaults.');
+      parsed = []; // Fallback to safe default state
+    }
+  }
+  return parsed;
+});
   const bellRef = useRef(null);
 
-  const savedCarbon = JSON.parse(localStorage.getItem("carbon-calculator-data") || "null");
+  const savedCarbon = (() => {
+  const saved = localStorage.getItem("carbon-calculator-data");
+  let parsed = null;
+  if (saved) {
+    try {
+      parsed = JSON.parse(saved);
+    } catch (error) {
+      console.warn('Corrupted localStorage data detected. Falling back to defaults.');
+      parsed = null; // Fallback to safe default state
+    }
+  }
+  return parsed;
+})();
 
   const allNotifications = [
     {


### PR DESCRIPTION
## Description
This PR improves the backend developer experience by adding a fail-fast startup check for the MongoDB connection string. Previously, if `MONGO_URI` was missing, the application would attempt to connect to an undefined URI, resulting in a cryptic Mongoose timeout error.

Fixes #214 

*(Note: This branch is cumulative and includes my recent approved fixes for the localStorage vulnerabilities and environment templates).*

## Changes Made:
* **Backend Validation:** Added an `if (!process.env.MONGO_URI)` check in `backend/index.js` right before the `mongoose.connect()` call.
* **Graceful Exit:** If the variable is missing, the server now logs a highly visible `FATAL ERROR` to the console and cleanly exits with `process.exit(1)`.

## Testing Performed
* [x] Renamed local `.env` to `.env.backup`.
* [x] Ran `npm run dev` in the backend.
* [x] Verified the terminal immediately output "FATAL ERROR: MONGO_URI is not defined in environment variables." and exited, rather than hanging.

## Type of Change
- [ ] 📚 Documentation update
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings